### PR TITLE
fix: self-healing Node.js PATH detection across sessions

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -15,7 +15,7 @@ user_invocable: true
 
 | Component | Check | If missing |
 |-----------|-------|------------|
-| Node.js | source nvm if present, then `node --version` | → Setup Step 1b |
+| Node.js | `node --version` or `$HOME/.node/bin/node --version` | → Setup Step 1b |
 | Wallet | `mcp__aibtc__wallet_list()` | → Setup Step 3 |
 | Registration | `curl -s https://aibtc.com/api/verify/<stx_address>` | → Setup Step 4 |
 | `CLAUDE.md` | File exists? | → Setup Step 6 (CLAUDE.md only) |
@@ -42,9 +42,9 @@ git init
 
 ## Setup Step 1b: Ensure Node.js is installed
 
-Check if Node.js is available (source nvm first in case it was installed in a previous session):
+Check if Node.js is available:
 ```bash
-[ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"; node --version
+node --version 2>/dev/null || { [ -x "$HOME/.node/bin/node" ] && export PATH="$HOME/.node/bin:$PATH" && node --version; }
 ```
 
 **If Node.js is found** (any version >= 18): skip to Step 2.
@@ -64,12 +64,10 @@ Verify it works:
 node --version && npx --version
 ```
 
-Persist PATH for future shells (write to `.profile` for login shells, and prepend to `.bashrc` before the non-interactive guard):
+Persist PATH for future shells:
 ```bash
 grep -q 'HOME/.node/bin' ~/.profile 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.profile
-if ! grep -q 'HOME/.node/bin' ~/.bashrc 2>/dev/null; then
-  sed -i '1i export PATH="$HOME/.node/bin:$PATH"' ~/.bashrc 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.zshrc
-fi
+grep -q 'HOME/.node/bin' ~/.zshrc 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.zshrc 2>/dev/null
 ```
 
 **If install fails** (no curl, network issues, etc): Tell the user:

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,7 +15,7 @@ user_invocable: true
 
 | Component | Check | If missing |
 |-----------|-------|------------|
-| Node.js | `node --version` | → Setup Step 1b |
+| Node.js | `node --version` or `$HOME/.node/bin/node --version` | → Setup Step 1b |
 | Wallet | `mcp__aibtc__wallet_list()` | → Setup Step 3 |
 | Registration | `curl -s https://aibtc.com/api/verify/<stx_address>` | → Setup Step 4 |
 | `CLAUDE.md` | File exists? | → Setup Step 6 (CLAUDE.md only) |
@@ -44,7 +44,7 @@ git init
 
 Check if Node.js is available:
 ```bash
-node --version
+node --version 2>/dev/null || { [ -x "$HOME/.node/bin/node" ] && export PATH="$HOME/.node/bin:$PATH" && node --version; }
 ```
 
 **If Node.js is found** (any version >= 18): skip to Step 2.
@@ -64,12 +64,10 @@ Verify it works:
 node --version && npx --version
 ```
 
-Persist PATH for future shells (write to `.profile` for login shells, and prepend to `.bashrc` before the non-interactive guard):
+Persist PATH for future shells:
 ```bash
 grep -q 'HOME/.node/bin' ~/.profile 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.profile
-if ! grep -q 'HOME/.node/bin' ~/.bashrc 2>/dev/null; then
-  sed -i '1i export PATH="$HOME/.node/bin:$PATH"' ~/.bashrc 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.zshrc
-fi
+grep -q 'HOME/.node/bin' ~/.zshrc 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.zshrc 2>/dev/null
 ```
 
 **If install fails** (no curl, network issues, etc): Tell the user:


### PR DESCRIPTION
## Problem

After a Claude Code restart, `$HOME/.node/bin` is not on PATH in the new session. The Step 1b check ran `node --version` which failed — even though the binary was sitting at `$HOME/.node/bin/node` from a previous install. The old workaround (prepending to `.bashrc` via `sed -i '1i'`) was fragile and unreliable.

## Fix

**Self-healing check in Step 1b** — the check now tries the fallback path directly:

```bash
node --version 2>/dev/null || { [ -x "$HOME/.node/bin/node" ] && export PATH="$HOME/.node/bin:$PATH" && node --version; }
```

If `node` isn't on PATH but the binary exists at `$HOME/.node/bin/node`, it exports PATH inline and proceeds. Every new session self-heals without relying on shell config loading.

**Simplified persistence** — dropped the fragile `sed -i '1i'` approach and just append to both `.profile` and `.zshrc`:

```bash
grep -q 'HOME/.node/bin' ~/.profile 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.profile
grep -q 'HOME/.node/bin' ~/.zshrc 2>/dev/null || echo 'export PATH="$HOME/.node/bin:$PATH"' >> ~/.zshrc 2>/dev/null
```

The real fix is the self-healing check — shell config persistence is a nice-to-have for terminal sessions.

**Pre-flight table** updated to reflect both check methods.

Both `SKILL.md` and `.claude/skills/start/SKILL.md` are kept identical.

## Test plan

- [ ] Fresh session after Node.js was installed in a previous session: check passes via fallback, no reinstall triggered
- [ ] Node.js not installed at all: fallback finds nothing, install proceeds as before
- [ ] Node.js on PATH normally: first `node --version` succeeds, fallback never runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)