### PR TITLE
fix: MCP server fails on restart — npx not on system PATH

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -89,6 +89,21 @@ ToolSearch: "+aibtc wallet"
 npx @aibtc/mcp-server@latest --install
 ```
 
+After install, patch `.mcp.json` so the MCP server can find `npx` on restart. The installer writes `"command": "npx"` (bare), which fails if `$HOME/.node/bin` isn't on the system PATH. Fix it by using the absolute path:
+```bash
+NPX_PATH=$(which npx)
+if [ -f .mcp.json ] && [ -n "$NPX_PATH" ]; then
+  sed -i "s|\"command\": \"npx\"|\"command\": \"$NPX_PATH\"|" .mcp.json
+fi
+```
+
+Verify the fix:
+```bash
+cat .mcp.json
+```
+
+The `"command"` field should now show the full path (e.g. `"/root/.node/bin/npx"` or `"/home/user/.node/bin/npx"`).
+
 After install completes, tell the user:
 > MCP server installed. **Restart your Claude Code / OpenClaw session** so the new MCP server loads, then run `/start` again.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,21 @@ ToolSearch: "+aibtc wallet"
 npx @aibtc/mcp-server@latest --install
 ```
 
+After install, patch `.mcp.json` so the MCP server can find `npx` on restart. The installer writes `"command": "npx"` (bare), which fails if `$HOME/.node/bin` isn't on the system PATH. Fix it by using the absolute path:
+```bash
+NPX_PATH=$(which npx)
+if [ -f .mcp.json ] && [ -n "$NPX_PATH" ]; then
+  sed -i "s|\"command\": \"npx\"|\"command\": \"$NPX_PATH\"|" .mcp.json
+fi
+```
+
+Verify the fix:
+```bash
+cat .mcp.json
+```
+
+The `"command"` field should now show the full path (e.g. `"/root/.node/bin/npx"` or `"/home/user/.node/bin/npx"`).
+
 After install completes, tell the user:
 > MCP server installed. **Restart your Claude Code / OpenClaw session** so the new MCP server loads, then run `/start` again.
 


### PR DESCRIPTION
## Problem

When `npx @aibtc/mcp-server@latest --install` runs, it writes `.mcp.json` with:

```json
{
  "mcpServers": {
    "aibtc": {
      "command": "npx",
      "args": ["@aibtc/mcp-server@1.27.0"]
    }
  }
}
```

Claude Code reads `.mcp.json` at startup and tries to spawn `npx`. But on systems where Node.js is installed to `$HOME/.node/bin/` (e.g. via the manual install in Step 1b), `npx` is not on the system PATH that Claude Code uses when launching MCP servers — because no shell profile is sourced at that point.

Result: MCP server fails to start on every restart even though Node.js is installed and working fine in the shell.

## Fix

In Step 2 of `SKILL.md` (and `.claude/skills/start/SKILL.md`), after the `npx --install` command, add a patch step that replaces the bare `"command": "npx"` with the absolute path returned by `which npx`:

```bash
NPX_PATH=$(which npx)
if [ -f .mcp.json ] && [ -n "$NPX_PATH" ]; then
  sed -i "s|\"command\": \"npx\"|\"command\": \"$NPX_PATH\"|" .mcp.json
fi
```

This is safe: `which npx` runs in the same shell that just successfully ran `npx --install`, so it will always find the right binary. The result is a `.mcp.json` with an absolute path like `"/root/.node/bin/npx"` that Claude Code can spawn without any PATH dependency.

## Files changed

- `SKILL.md` — Step 2 updated
- `.claude/skills/start/SKILL.md` — kept identical to `SKILL.md`