### PR TITLE
fix(security): replace Python subprocess JSON with jq

### DIFF
--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -209,7 +209,8 @@ signature = mcp__aibtc__btc_sign_message(sign_message)
 Use Bash/curl instead, with your STX address from CLAUDE.md:
 ```bash
 export MSG_ID="<id>" REPLY_TEXT="<text>" SIG="<base64>"
-PAYLOAD=$(python3 -c "import json,os; print(json.dumps({'messageId':os.environ['MSG_ID'],'reply':os.environ['REPLY_TEXT'],'signature':os.environ['SIG']}))")
+PAYLOAD=$(jq -n --arg mid "$MSG_ID" --arg reply "$REPLY_TEXT" --arg sig "$SIG" \
+  '{messageId: $mid, reply: $reply, signature: $sig}')
 curl -s -X POST https://aibtc.com/api/outbox/{stx_address} \
   -H "Content-Type: application/json" -d "$PAYLOAD"
 ```


### PR DESCRIPTION
## Summary

Fixes #32.

The reply mechanics section in `daemon/loop.md` used a Python subprocess invocation to construct JSON:

```bash
PAYLOAD=$(python3 -c "import json,os; print(json.dumps({'messageId':os.environ['MSG_ID'],'reply':os.environ['REPLY_TEXT'],'signature':os.environ['SIG']}))")
```

This pattern is a shell injection risk: if `REPLY_TEXT` contains special characters (single quotes, backticks, `$(...)` sequences), they could break out of the Python `-c` string and execute arbitrary shell commands.

## Fix

Replace with `jq --arg` flags, which handle all special characters safely by passing values as arguments rather than interpolating them into a shell string:

```bash
PAYLOAD=$(jq -n --arg mid "$MSG_ID" --arg reply "$REPLY_TEXT" --arg sig "$SIG" \
  '{messageId: $mid, reply: $reply, signature: $sig}')
```

`jq` is available on all major Linux distributions and macOS. It is the standard tool for shell-safe JSON construction and is already a common dependency in agent toolchains.

## Test plan

- [ ] Verify `jq` is present: `which jq`
- [ ] Test with a reply containing special characters (e.g. quotes, backticks): confirm JSON is valid and no injection occurs
- [ ] Confirm the produced payload is accepted by `POST https://aibtc.com/api/outbox/{stx_address}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)