### PR TITLE
fix(outreach): retry limits, error classification, and circuit breaker for Phase 6

### DIFF
--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -290,18 +290,28 @@ Before sending, check if the day has changed since `last_reset` in `daemon/outbo
 
 Read `daemon/outbox.json` for items in the `pending` list.
 
+**Circuit breaker check:** Before processing any pending messages, check `budget.consecutive_failures` in `outbox.json`. If it is >= 3, check `budget.outreach_paused_until`. If the current time is before `outreach_paused_until`, skip all sends this cycle and log: "Outreach paused (circuit breaker): N failures in a row". If the pause has expired, reset `consecutive_failures` to 0 and clear `outreach_paused_until`.
+
 For each pending message, run these checks in order:
-1. **Budget check**: `spent_today_sats + 100 <= daily_limit_sats`
-2. **Cooldown check**: Scan `outbox.json` `sent` list for the same `recipient_stx`. If any entry has `sent_at` within the last 24 hours, skip this recipient. (Cooldown = 24h per agent.)
-3. **Duplicate check**: Compare `content` against all `sent` entries to the same recipient. Skip if identical content was already sent.
-4. **Balance check**: Verify sBTC balance >= 100 sats via MCP tool.
+1. **Retry limit check**: If the message has `attempts >= 2`, mark it as `"status": "failed"` with `last_error` preserved, move to a `failed` list (not `sent`), and skip. Do not retry exhausted messages.
+2. **Retry cooldown check**: If `attempts >= 1` and `last_failed_at` is set, skip this message unless at least one full cycle has elapsed since `last_failed_at` (use `next_cycle_at` from health.json, or check that current time >= `last_failed_at` + 300s). This lets the mempool/nonce clear.
+3. **Budget check**: `spent_today_sats + 100 <= daily_limit_sats`
+4. **Cooldown check**: Scan `outbox.json` `sent` list for the same `recipient_stx`. If any entry has `sent_at` within the last 24 hours, skip this recipient. (Cooldown = 24h per agent.)
+5. **Duplicate check**: Compare `content` against all `sent` entries to the same recipient. Skip if identical content was already sent.
+6. **Balance check**: Verify sBTC balance >= 100 sats via MCP tool.
 
 If all checks pass:
 - Send: `send_inbox_message(recipientStxAddress: "...", recipientBtcAddress: "...", content: "...")`
-- On success: Move from `pending` to `sent` with timestamp and cost
-- On failure: Leave in `pending`, retry next cycle
+- **On success**: Move from `pending` to `sent` with timestamp, cost, and API-returned `message_id` and `tx_id`. Reset `consecutive_failures` to 0 in budget.
+- **On failure**: Classify the error (see below), increment `attempts`, set `last_failed_at` to now, set `last_error` to the classified error type. Increment `budget.consecutive_failures`. If `consecutive_failures` reaches 3, set `budget.outreach_paused_until` = now + 5 cycles (now + 1500s). Leave message in `pending` for retry.
 
-Record: `{ event: "outreach", sent: N, failed: N, cost_sats: N }`
+**Error classification** (set as `last_error` on the pending entry):
+- `"relay_down"` — error contains `SETTLEMENT_BROADCAST_FAILED` or HTTP 5xx from relay. **Sats NOT spent.** Safe to retry immediately next cycle.
+- `"rbf_drop"` — error contains `dropped_replace_by_fee`. **Sats NOT spent** (tx was replaced). Safe to retry after 1 cycle cooldown.
+- `"timeout"` — error contains `TimeoutError` or `SETTLEMENT_TIMEOUT`. **Sats MAY have been spent.** Before retrying: check `paymentTxid` from the error response on-chain via `mcp__aibtc__get_transaction_status(txid)`. If confirmed, message was likely delivered — move to `sent` without resending. If not found, safe to retry.
+- `"unknown"` — any other error. Treat as `timeout` (assume sats may be spent).
+
+Record: `{ event: "outreach", sent: N, failed: N, exhausted: N, paused: bool, cost_sats: N }`
 
 ### 6c. Check follow-ups
 
@@ -329,8 +339,8 @@ Iteration logic -- for each follow-up entry:
 4. If both conditions are met:
    - Apply budget check, cooldown check, duplicate check, and balance check
    - Send the reminder via `send_inbox_message`
-   - On success: increment `reminder_count`, update `check_after` for next interval
-   - On failure: leave unchanged, retry next cycle
+   - On success: increment `reminder_count`, update `check_after` for next interval. Reset `budget.consecutive_failures` to 0.
+   - On failure: classify the error (relay_down / rbf_drop / timeout / unknown, same rules as 6b), increment `budget.consecutive_failures`, leave unchanged for retry next cycle
 5. If `reminder_count >= max_reminders`: mark the entry as `completed` and remove from active list
 
 ### 6d. Update outbox state
@@ -453,7 +463,11 @@ sleep 300
 | Inbox | HTTP error | Log, skip to Execute |
 | Execute | Task fails | Mark failed, continue to Deliver |
 | Deliver | Reply fails | Log, retry next cycle |
-| Outreach | Send fails | Leave in pending, retry next cycle |
+| Outreach | Send fails (relay_down) | Classify error, increment attempts, retry next cycle (sats not spent) |
+| Outreach | Send fails (rbf_drop) | Classify error, increment attempts, wait 1 cycle cooldown before retry (sats not spent) |
+| Outreach | Send fails (timeout) | Classify error, check paymentTxid on-chain before retrying (sats may be spent) |
+| Outreach | 2 attempts exhausted | Move to `failed` list, do not retry |
+| Outreach | 3+ consecutive failures | Set circuit breaker: pause outreach for 5 cycles (1500s) |
 | Outreach | Budget exceeded | Skip remaining sends, continue |
 | Reflect | File write fails | Log to console, continue |
 | Evolve | Edit fails | Skip, don't corrupt loop.md |
@@ -508,16 +522,34 @@ sleep 300
       "recipient_stx": "SP...",
       "recipient_btc": "bc1...",
       "content": "message text",
-      "purpose": "introduction|announcement|follow_up"
+      "purpose": "introduction|announcement|follow_up",
+      "attempts": 0,
+      "last_failed_at": null,
+      "last_error": null
+    }
+  ],
+  "failed": [
+    {
+      "id": "out_003",
+      "recipient": "Agent Name",
+      "recipient_stx": "SP...",
+      "recipient_btc": "bc1...",
+      "content": "message text",
+      "purpose": "introduction",
+      "attempts": 2,
+      "last_failed_at": "ISO timestamp",
+      "last_error": "timeout|rbf_drop|relay_down|unknown"
     }
   ],
   "follow_ups": [],
-  "next_id": 3,
+  "next_id": 4,
   "budget": {
     "cycle_limit_sats": 200,
     "daily_limit_sats": 200,
     "spent_today_sats": 0,
-    "last_reset": "ISO timestamp"
+    "last_reset": "ISO timestamp",
+    "consecutive_failures": 0,
+    "outreach_paused_until": null
   }
 }
 ```

--- a/daemon/outbox.json
+++ b/daemon/outbox.json
@@ -7,15 +7,21 @@
       "recipient_stx": "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
       "recipient_btc": "bc1qqaxq5vxszt0lzmr9gskv4lcx7jzrg772s4vxpp",
       "content": "New agent online via loop-starter-kit. Ready to collaborate.",
-      "purpose": "introduction"
+      "purpose": "introduction",
+      "attempts": 0,
+      "last_failed_at": null,
+      "last_error": null
     }
   ],
+  "failed": [],
   "follow_ups": [],
   "next_id": 2,
   "budget": {
     "cycle_limit_sats": 200,
     "daily_limit_sats": 200,
     "spent_today_sats": 0,
-    "last_reset": "1970-01-01T00:00:00.000Z"
+    "last_reset": "1970-01-01T00:00:00.000Z",
+    "consecutive_failures": 0,
+    "outreach_paused_until": null
   }
 }


### PR DESCRIPTION
## Summary

- Track `attempts`, `last_failed_at`, and `last_error` on each `pending` outbox entry
- Max 2 retry attempts per recipient; exhausted entries move to a new `failed` list
- After any failure, enforce a 1-cycle (300s) cooldown before retrying so mempool/nonce clears
- Classify errors: `relay_down` (sats not spent), `rbf_drop` (sats not spent, needs cooldown), `timeout` (sats may be spent — check `paymentTxid` on-chain before retrying), `unknown` (treat as timeout)
- Circuit breaker: 3+ consecutive failures pause outreach for 5 cycles (1500s) via `budget.outreach_paused_until`
- Update `daemon/outbox.json` template and Reference schema with new fields
- Update Failure Recovery table with per-error-type actions

## Motivation

Real-world failure from our loop: Cunning Astra (SP8KCB9KXP0ZRMMAJNP7E8QRYYXC9YDT31TFNAMS) had two consecutive outreach failures — `dropped_replace_by_fee` then `TimeoutError` — across back-to-back cycles. The agent silently left the message in `pending` and retried with no limit. One attempt burned 100 sats (timeout — sats may have been spent) without confirmed delivery. With this fix, the agent will classify each error, track how many times it has tried, check the txid on-chain for timeout errors before retrying, and stop after 2 attempts. A sustained relay outage now triggers a 5-cycle pause instead of burning sats every cycle.

## Files changed

- `daemon/loop.md` — Phase 6b rewritten; 6c updated; Failure Recovery table expanded; Reference schema updated
- `daemon/outbox.json` — template updated with `attempts`, `last_failed_at`, `last_error`, `failed` list, `consecutive_failures`, `outreach_paused_until`

## Test plan

- [ ] Verify outbox.json template is valid JSON after change
- [ ] Read through Phase 6b and confirm all 4 error types have clear retry guidance
- [ ] Confirm circuit breaker check appears before per-message processing
- [ ] Confirm `failed` list exists in schema so agents know where to write exhausted entries

Closes #34

Generated with [Claude Code](https://claude.com/claude-code)