### PR TITLE
fix: replace hardcoded wallet name with placeholder

### DIFF
--- a/.claude/skills/loop-start/daemon/loop.md
+++ b/.claude/skills/loop-start/daemon/loop.md
@@ -4,7 +4,7 @@
 > CEO Operating Manual (daemon/ceo.md) is the decision engine.
 >
 > **Setup note:** All `{PLACEHOLDER}` values must be filled from your CLAUDE.md before running the loop.
-> Replace: `{AGENT_STX_ADDRESS}`, `{GITHUB_USERNAME}`, `{GIT_AUTHOR_NAME}`, `{GIT_AUTHOR_EMAIL}`, `{SSH_KEY_PATH}`.
+> Replace: `{AGENT_WALLET_NAME}`, `{AGENT_STX_ADDRESS}`, `{GITHUB_USERNAME}`, `{GIT_AUTHOR_NAME}`, `{GIT_AUTHOR_EMAIL}`, `{SSH_KEY_PATH}`.
 
 ## Phases
 1. Setup  2. Observe  3. Decide  4. Execute  5. Deliver  6. Outreach  7. Reflect  8. Evolve  9. Sync  10. Sleep
@@ -18,7 +18,7 @@
 Load MCP tools (skip if already loaded this session):
 `ToolSearch: "+aibtc wallet"` / `"+aibtc sign"` / `"+aibtc inbox"`
 
-Unlock wallet: `mcp__aibtc__wallet_unlock(name: "secret mars name", password: <operator>)`
+Unlock wallet: `mcp__aibtc__wallet_unlock(name: "{AGENT_WALLET_NAME}", password: <operator>)`
 
 **Warm tier (every cycle):** queue.json, processed.json, learnings.md, portfolio.md, **ceo.md sections 1-5**
 **Cool tier (on-demand):** outbox.json (Phase 6), contacts.md (scouting/inbox/outreach), journal.md (append-only)

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -4,7 +4,7 @@
 > CEO Operating Manual (daemon/ceo.md) is the decision engine.
 >
 > **Setup note:** All `{PLACEHOLDER}` values must be filled from your CLAUDE.md before running the loop.
-> Replace: `{AGENT_STX_ADDRESS}`, `{GITHUB_USERNAME}`, `{GIT_AUTHOR_NAME}`, `{GIT_AUTHOR_EMAIL}`, `{SSH_KEY_PATH}`.
+> Replace: `{AGENT_WALLET_NAME}`, `{AGENT_STX_ADDRESS}`, `{GITHUB_USERNAME}`, `{GIT_AUTHOR_NAME}`, `{GIT_AUTHOR_EMAIL}`, `{SSH_KEY_PATH}`.
 
 ## Phases
 1. Setup  2. Observe  3. Decide  4. Execute  5. Deliver  6. Outreach  7. Reflect  8. Evolve  9. Sync  10. Sleep
@@ -18,7 +18,7 @@
 Load MCP tools (skip if already loaded this session):
 `ToolSearch: "+aibtc wallet"` / `"+aibtc sign"` / `"+aibtc inbox"`
 
-Unlock wallet: `mcp__aibtc__wallet_unlock(name: "secret mars name", password: <operator>)`
+Unlock wallet: `mcp__aibtc__wallet_unlock(name: "{AGENT_WALLET_NAME}", password: <operator>)`
 
 **Warm tier (every cycle):** queue.json, processed.json, learnings.md, portfolio.md, **ceo.md sections 1-5**
 **Cool tier (on-demand):** outbox.json (Phase 6), contacts.md (scouting/inbox/outreach), journal.md (append-only)


### PR DESCRIPTION
## Summary
This PR completes the placeholder migration from PR #48 by replacing the remaining hardcoded wallet name value.

## Changes
- Replace hardcoded `"secret mars name"` with `{AGENT_WALLET_NAME}` placeholder in:
  - `/daemon/loop.md` line 21 (Phase 1 Setup)
  - `/.claude/skills/loop-start/daemon/loop.md` line 21
- Update setup documentation to include `{AGENT_WALLET_NAME}` in the placeholder list:
  - `/daemon/loop.md` line 7
  - `/.claude/skills/loop-start/daemon/loop.md` line 7

## Motivation
This ensures that all templated configuration values in the loop-starter-kit are consistently replaced from the agent's CLAUDE.md during setup. Without this, agents copying the template could end up with hardcoded wallet configuration errors.

## Files Modified
- `/daemon/loop.md` (2 changes)
- `/.claude/skills/loop-start/daemon/loop.md` (2 changes)