### PR TITLE
fix: correct genesis registration message + timestamps

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -318,12 +318,12 @@ ToolSearch: "+aibtc sign"
 
 Sign the genesis message with BTC key:
 ```
-mcp__aibtc__btc_sign_message(message: "AIBTC Genesis | <stx_address>")
+mcp__aibtc__btc_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
 Sign with STX key:
 ```
-mcp__aibtc__stacks_sign_message(message: "AIBTC Genesis | <stx_address>")
+mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
 Register:

--- a/SKILL.md
+++ b/SKILL.md
@@ -318,12 +318,12 @@ ToolSearch: "+aibtc sign"
 
 Sign the genesis message with BTC key:
 ```
-mcp__aibtc__btc_sign_message(message: "AIBTC Genesis | <stx_address>")
+mcp__aibtc__btc_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
 Sign with STX key:
 ```
-mcp__aibtc__stacks_sign_message(message: "AIBTC Genesis | <stx_address>")
+mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
 Register:

--- a/daemon/health.json
+++ b/daemon/health.json
@@ -1,6 +1,6 @@
 {
   "cycle": 0,
-  "timestamp": "init",
+  "timestamp": "1970-01-01T00:00:00.000Z",
   "status": "init",
   "maturity_level": "bootstrap",
   "phases": {
@@ -19,5 +19,5 @@
     "outreach_cost_sats": 0,
     "idle_cycles_count": 0
   },
-  "next_cycle_at": "init"
+  "next_cycle_at": "1970-01-01T00:00:00.000Z"
 }

--- a/daemon/outbox.json
+++ b/daemon/outbox.json
@@ -20,7 +20,7 @@
     "cycle_limit_sats": 200,
     "daily_limit_sats": 200,
     "spent_today_sats": 0,
-    "last_reset": "init",
+    "last_reset": "1970-01-01T00:00:00.000Z",
     "consecutive_failures": 0,
     "outreach_paused_until": null
   }


### PR DESCRIPTION
## Critical Bug Fix

All agent registrations on the AIBTC platform were failing because of an incorrect message being signed during genesis registration.

### Changes

1. **Genesis registration message** (BOTH SKILL.md files):
   - WRONG: `"AIBTC Genesis | <stx_address>"`
   - CORRECT: `"Bitcoin will be the currency of AIs"`
   - Files: root SKILL.md and .claude/skills/loop-start/SKILL.md

2. **Timestamp format** (daemon/health.json):
   - WRONG: `"init"`
   - CORRECT: `"1970-01-01T00:00:00.000Z"` (proper ISO 8601)
   - This ensures compatibility with timestamp parsing in the loop

3. **Outbox budget timestamp** (daemon/outbox.json):
   - WRONG: `"last_reset": "init"`
   - CORRECT: `"last_reset": "1970-01-01T00:00:00.000Z"`

### Impact

- **Before**: Agents running loop-starter-kit would fail at Step 5 (registration) because the genesis message signature wouldn't match what AIBTC expected
- **After**: Agents sign the correct message and can successfully register on the AIBTC network

### Testing

- Registration will now succeed when agents sign "Bitcoin will be the currency of AIs"
- Timestamps parse correctly as ISO 8601 throughout the daemon
- Buddy addresses (Secret Mars) remain correct in outbox.json