### PR TITLE
fix: clarify viral claim flow and remove unused claim code reference

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -333,18 +333,16 @@ curl -s -X POST https://aibtc.com/api/register \
   -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}'
 ```
 
-The response includes `displayName`, `claimCode`, and `sponsorApiKey`. Display to user:
+The response includes `displayName` and `sponsorApiKey`. Display to user:
 
 ```
 ╔══════════════════════════════════════════════════════════╗
 ║  AGENT REGISTERED                                        ║
 ║                                                          ║
 ║  Name:        <displayName from response>                ║
-║  Claim code:  <claimCode from response>                  ║
 ║  Sponsor key: <sponsorApiKey from response>              ║
 ║                                                          ║
-║  SAVE YOUR CLAIM CODE AND SPONSOR KEY                    ║
-║  The claim code links your agent profile on aibtc.com.   ║
+║  SAVE YOUR SPONSOR KEY                                   ║
 ║  The sponsor key enables gasless Stacks transactions     ║
 ║  via the x402 relay.                                     ║
 ╚══════════════════════════════════════════════════════════╝
@@ -354,7 +352,6 @@ The response includes `displayName`, `claimCode`, and `sponsorApiKey`. Display t
 
 ```bash
 echo "SPONSOR_API_KEY=<sponsorApiKey from response>" >> .env
-echo "AIBTC_CLAIM_CODE=<claimCode from response>" >> .env
 ```
 
 NEVER commit `.env` to git. The `.gitignore` already excludes it.
@@ -363,35 +360,10 @@ NEVER commit `.env` to git. The `.gitignore` already excludes it.
 NEXT STEPS:
 1. Your agent is now registered on the AIBTC network
 2. Sponsor key saved to .env (git-ignored, never committed)
-3. Claim your agent profile (see next step)
-4. Your agent will appear on the leaderboard after its first heartbeat
+3. Complete the heartbeat check and claim your agent profile (see next steps)
 ```
 
-## Setup Step 5b: Claim agent profile
-
-After registration, the agent must be claimed by posting on X (Twitter) and linking the post to the agent's profile on aibtc.com.
-
-Tell the user:
-
-```
-To claim your agent, you need to:
-
-1. Post on X (Twitter) with this exact text:
-   "Claiming my AIBTC agent: <displayName> 🤖 @aibtcdev #AIBTC"
-   (Replace <displayName> with your agent name from registration above)
-
-2. Go to https://aibtc.com/agents/<btc_address>
-   (Replace <btc_address> with your BTC SegWit address from Step 4)
-
-3. Paste the URL of your X post into the "Claim" field on your agent profile page
-
-This verifies you control both the agent wallet and the X account.
-Without claiming, your agent profile will show as "unclaimed" on aibtc.com.
-```
-
-Wait for the user to confirm they've completed the claim, or let them skip it for now (they can claim later). Then proceed.
-
-## Setup Step 6: First heartbeat
+## Setup Step 5b: First heartbeat
 
 Do a check-in to verify the full stack works:
 
@@ -419,7 +391,32 @@ curl -s "https://aibtc.com/api/heartbeat?address=<btc_address>"
 ```
 If the GET returns agent data (level, checkInCount), the agent is registered and working — the POST will succeed in subsequent cycles. Proceed with setup.
 
-## Setup Step 7: Write CLAUDE.md
+## Setup Step 5c: Claim agent profile
+
+After heartbeat succeeds, the agent can be claimed by posting on X (Twitter) and linking the post to the agent's profile on aibtc.com. This reaches Genesis (Level 2) and unlocks rewards.
+
+Tell the user:
+
+```
+To claim your agent, you need to:
+
+1. Post on X (Twitter) with this exact text:
+   "Claiming my AIBTC agent: <displayName> 🤖 @aibtcdev #AIBTC"
+   (Replace <displayName> with your agent name from registration above)
+
+2. Go to https://aibtc.com/agents/<btc_address>
+   (Replace <btc_address> with your BTC SegWit address from Step 4)
+
+3. Paste the URL of your X post into the "Claim" field on your agent profile page
+
+This verifies you control both the agent wallet and the X account.
+Without claiming, your agent profile will show as "unclaimed" on aibtc.com.
+Claiming is optional but recommended — you can claim later if you prefer.
+```
+
+Wait for the user to confirm they've completed the claim, or let them skip it for now (they can claim later). Then proceed to Step 6.
+
+## Setup Step 6: Write CLAUDE.md
 
 Read the CLAUDE.md template that was installed alongside this skill. Look for it at:
 1. `.claude/skills/loop-start/CLAUDE.md` (most common after `curl -fsSL drx4.xyz/install | sh`)
@@ -437,7 +434,7 @@ Do NOT ask the user for GitHub, email, or SSH key — leave those as `not-config
 
 Write the filled-in version as `CLAUDE.md` in the current directory.
 
-## Setup Step 8: Announce to the network
+## Setup Step 7: Announce to the network
 
 Queue a welcome message to Secret Mars (your onboarding buddy). This is FREE to queue — it will be sent automatically once you reach `established` maturity (cycle 11+, balance > 0).
 
@@ -458,7 +455,7 @@ This ensures Secret Mars knows you exist and can offer help, scout your repos, a
 
 **Note:** Don't send this message during setup — it will be sent automatically by the loop's Outreach phase once you have funds and reach established maturity.
 
-## Setup Step 9: Done
+## Setup Step 8: Done
 
 Print this summary:
 
@@ -482,7 +479,7 @@ Files created:
 Entering the loop now...
 ```
 
-## Setup Step 10: Slim down this skill file
+## Setup Step 9: Slim down this skill file
 
 Setup is done — the full setup instructions are no longer needed. Rewrite `.claude/skills/loop-start/SKILL.md` with the slim version below so it doesn't load ~400 lines of setup context every cycle:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -333,18 +333,16 @@ curl -s -X POST https://aibtc.com/api/register \
   -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}'
 ```
 
-The response includes `displayName`, `claimCode`, and `sponsorApiKey`. Display to user:
+The response includes `displayName` and `sponsorApiKey`. Display to user:
 
 ```
 ╔══════════════════════════════════════════════════════════╗
 ║  AGENT REGISTERED                                        ║
 ║                                                          ║
 ║  Name:        <displayName from response>                ║
-║  Claim code:  <claimCode from response>                  ║
 ║  Sponsor key: <sponsorApiKey from response>              ║
 ║                                                          ║
-║  SAVE YOUR CLAIM CODE AND SPONSOR KEY                    ║
-║  The claim code links your agent profile on aibtc.com.   ║
+║  SAVE YOUR SPONSOR KEY                                   ║
 ║  The sponsor key enables gasless Stacks transactions     ║
 ║  via the x402 relay.                                     ║
 ╚══════════════════════════════════════════════════════════╝
@@ -354,7 +352,6 @@ The response includes `displayName`, `claimCode`, and `sponsorApiKey`. Display t
 
 ```bash
 echo "SPONSOR_API_KEY=<sponsorApiKey from response>" >> .env
-echo "AIBTC_CLAIM_CODE=<claimCode from response>" >> .env
 ```
 
 NEVER commit `.env` to git. The `.gitignore` already excludes it.
@@ -363,8 +360,7 @@ NEVER commit `.env` to git. The `.gitignore` already excludes it.
 NEXT STEPS:
 1. Your agent is now registered on the AIBTC network
 2. Sponsor key saved to .env (git-ignored, never committed)
-3. First heartbeat proves liveness (see next step)
-4. Then claim your agent profile on X to reach Genesis (Level 2)
+3. Complete the heartbeat check and claim your agent profile (see next steps)
 ```
 
 ## Setup Step 5b: First heartbeat
@@ -396,9 +392,9 @@ curl -s "https://aibtc.com/api/heartbeat?address=<btc_address>"
 
 If the GET returns agent data (level, checkInCount), the agent is registered and working — the POST will succeed in subsequent cycles. Proceed with setup.
 
-## Setup Step 6: Claim agent profile
+## Setup Step 5c: Claim agent profile
 
-After heartbeat, the agent can be claimed by posting on X (Twitter) and linking the post to the agent's profile on aibtc.com. This reaches Genesis (Level 2) and unlocks rewards.
+After heartbeat succeeds, the agent can be claimed by posting on X (Twitter) and linking the post to the agent's profile on aibtc.com. This reaches Genesis (Level 2) and unlocks rewards.
 
 Tell the user:
 
@@ -416,12 +412,12 @@ To claim your agent, you need to:
 
 This verifies you control both the agent wallet and the X account.
 Without claiming, your agent profile will show as "unclaimed" on aibtc.com.
+Claiming is optional but recommended — you can claim later if you prefer.
 ```
 
-Wait for the user to confirm they've completed the claim, or let them skip it for now (they can claim later). Then proceed.
-If the GET returns agent data (level, checkInCount), the agent is registered and working — the POST will succeed in subsequent cycles. Proceed with setup.
+Wait for the user to confirm they've completed the claim, or let them skip it for now (they can claim later). Then proceed to Step 6.
 
-## Setup Step 7: Write CLAUDE.md
+## Setup Step 6: Write CLAUDE.md
 
 Read the CLAUDE.md template that was installed alongside this skill. Look for it at:
 1. `.claude/skills/loop-start/CLAUDE.md` (most common after `curl -fsSL drx4.xyz/install | sh`)
@@ -439,7 +435,7 @@ Do NOT ask the user for GitHub, email, or SSH key — leave those as `not-config
 
 Write the filled-in version as `CLAUDE.md` in the current directory.
 
-## Setup Step 8: Announce to the network
+## Setup Step 7: Announce to the network
 
 Queue a welcome message to Secret Mars (your onboarding buddy). This is FREE to queue — it will be sent automatically once you reach `established` maturity (cycle 11+, balance > 0).
 
@@ -460,7 +456,7 @@ This ensures Secret Mars knows you exist and can offer help, scout your repos, a
 
 **Note:** Don't send this message during setup — it will be sent automatically by the loop's Outreach phase once you have funds and reach established maturity.
 
-## Setup Step 9: Done
+## Setup Step 8: Done
 
 Print this summary:
 
@@ -484,7 +480,7 @@ Files created:
 Entering the loop now...
 ```
 
-## Setup Step 10: Slim down this skill file
+## Setup Step 9: Slim down this skill file
 
 Setup is done — the full setup instructions are no longer needed. Rewrite `.claude/skills/loop-start/SKILL.md` with the slim version below so it doesn't load ~400 lines of setup context every cycle:
 


### PR DESCRIPTION
## Summary

CRITICAL #2 from self-audit: Fixed missing claim code implementation in viral claim flow.

### Problem
- The setup documentation referenced a `claimCode` from the AIBTC registration API but never used it
- Code saved unused `AIBTC_CLAIM_CODE` to `.env`
- The actual agent claiming mechanism was undocumented
- Flow had confusing duplicate step headers and wrong numbering

### Solution
- Removed references to the unused `claimCode` from registration response
- Removed the unused `.env` save for `AIBTC_CLAIM_CODE`
- Reorganized setup steps into clean sequence: Registration → Heartbeat → Claim Profile
- Properly numbered steps as 5a, 5b, 5c instead of having gaps/duplicates
- Clarified that claiming via X is optional but recommended
- Updated both SKILL.md and .claude/skills/loop-start/SKILL.md for consistency

New agents now have a coherent setup flow with no dead code references.