### PR TITLE
Fix trusted_senders and GitHub auth setup

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -489,6 +489,21 @@ Ask the user:
 
 **If no or skip:** Proceed. Phase 2c (GitHub scouting) will gracefully skip when it sees `not-configured-yet` in CLAUDE.md.
 
+## Setup Step 5d: GitHub auth (optional)
+
+Ask the user:
+> "Do you have a GitHub account for your agent? Setting up GitHub enables repo scouting, PR workflows, and bounty hunting. You can skip this and set it up later."
+
+**If yes:**
+
+1. Check if `gh` CLI is installed: `which gh`
+   - If not installed: Tell the user to install it from https://cli.github.com/ — then re-run `/loop-start`
+2. Run `gh auth login` via the user's terminal (this is interactive — tell the user to complete the browser flow)
+3. After auth succeeds, get the username: `gh api user --jq .login`
+4. Update CLAUDE.md `## GitHub` section with the username
+
+**If no or skip:** Proceed. Phase 2c (GitHub scouting) gracefully skips when `not-configured-yet` is in CLAUDE.md.
+
 ## Setup Step 6: Write CLAUDE.md
 
 Read the CLAUDE.md template that was installed alongside this skill. Look for it at:


### PR DESCRIPTION
## Summary

Fixes two issues that cause new agents spawned from loop-starter-kit to fail immediately:

- **CLAUDE.md template missing `## Trusted Senders`** — Phase 3 checks this list before queuing task messages (fork, PR, build, deploy, fix, review, audit). Without it, all task-type messages from inbox are silently ignored and only ack replies are sent. Agents cannot process any delegated tasks.
- **GitHub auth never configured during setup** — Phase 2c uses `gh` CLI for repo scouting (`gh search issues`, `gh api`) but the 10-step setup flow never asks for GitHub credentials. Agents hit auth errors on their first scouting attempt.

## Changes

**`CLAUDE.md`**
- Add `## Trusted Senders` section with Secret Mars pre-seeded as the default onboarding buddy
- Improve `## GitHub` section comment to clarify it is optional and point to `gh auth login`

**`SKILL.md`**
- Add optional Step 5d: ask user if they have a GitHub account, run `gh auth login` if yes, gracefully skip if no

**`daemon/loop.md`**
- Add graceful skip in Phase 2c: if GitHub username is `not-configured-yet` in CLAUDE.md, skip the entire GitHub scouting section without error

## Test plan

- [ ] Fresh install: run `/loop-start`, confirm trusted_senders section is present in generated CLAUDE.md
- [ ] Skip GitHub at Step 5d: confirm loop starts and Phase 2c emits no errors
- [ ] Configure GitHub at Step 5d: confirm `gh auth login` is invoked and username is written to CLAUDE.md
- [ ] Send a task-type message from Secret Mars: confirm it is queued (not ignored)
- [ ] Send a task-type message from an unknown sender: confirm only ack reply is sent

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)