### PR TITLE
fix(template): correct reply length formula and harden placeholder validation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -623,9 +623,14 @@ Detect the execution environment before entering the loop:
 
 Before entering the loop, verify no unfilled placeholders remain:
 ```bash
-grep -rn '{AGENT_\|{YOUR_\|\[YOUR_' CLAUDE.md daemon/loop.md 2>/dev/null
+UNFILLED=$(grep -rn '{AGENT_\|{YOUR_\|\[YOUR_' CLAUDE.md daemon/loop.md 2>/dev/null)
+if [ -n "$UNFILLED" ]; then
+  echo "ERROR: Unfilled placeholders found — fix these before starting the loop:"
+  echo "$UNFILLED"
+  exit 1
+fi
 ```
-If any matches are found, print the matches and stop — tell the user which placeholders need filling. Do NOT enter the loop with unfilled placeholders.
+If any matches are found, print them and stop. Do NOT enter the loop with unfilled placeholders — they will cause runtime failures (wrong addresses, broken signing, etc.).
 
 ### Loop Entry
 

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -234,7 +234,7 @@ Any phase fails → log it, increment circuit breaker, continue to next phase.
 
 ## Reply Mechanics
 
-- Max 500 chars total signature string. Safe reply ~418 chars.
+- Max 500 chars total signature string. Safe reply = 500 - 16 - len(messageId) chars.
 - Sign: `"Inbox Reply | {messageId} | {reply_text}"`
 - Use `-d @file` NOT `-d '...'` — shell mangles base64
 - ASCII only — em-dashes break sig verification


### PR DESCRIPTION
## Summary

Fixes two items from issue #50 that were regressed or only partially addressed by the v6 loop upgrade (PR #73):

- **Reply length formula (daemon/loop.md)**: The v6 upgrade replaced the precise "500 - 17 - len(messageId)" wording from the original #50 fix with a vague "~418 chars" estimate. This PR restores an exact formula using the correct fixed overhead of 16 chars (per the issue spec).

- **Placeholder validation (SKILL.md)**: The existing grep check was a one-liner with no enforcement — the LLM could ignore the output and proceed anyway. This PR wraps it in a proper `if [ -n "$UNFILLED" ]` block with `exit 1`, making the validation actually block loop entry when unfilled `{AGENT_*}` or `[YOUR_*}` placeholders are found in CLAUDE.md or daemon/loop.md.

## Files changed

- `/daemon/loop.md` — Reply Mechanics section: `~418 chars` → `500 - 16 - len(messageId) chars`
- `/SKILL.md` — Placeholder Validation: bare grep → if/then block with `exit 1`

## Test plan

- [ ] Confirm `grep -n "Safe reply" daemon/loop.md` shows the formula, not a rough estimate
- [ ] Confirm a fresh agent setup with an unfilled `[YOUR_STX_ADDRESS]` in CLAUDE.md is blocked at loop entry with a clear error message
- [ ] Confirm a fully-configured agent passes the validation and enters the loop normally

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)