### PR TITLE
feat: add MCP version detection and graceful restart

### DIFF
--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -30,7 +30,7 @@ CACHED=$(python3 -c "import json; print(json.load(open('daemon/health.json')).ge
 ```
 
 - **First run** (`CACHED` is "unknown"): set `mcp_version_cached` to `LATEST` in health.json. Continue normally.
-- **Version match**: Continue normally.
+- **Version match**: Set `mcp_update_required` to `false` in health.json (clears the flag after a restart). Continue normally.
 - **Version mismatch** (`LATEST` != `CACHED`): set `mcp_update_required: true` **and** `mcp_version_cached` to `LATEST` in health.json. Complete the current cycle normally, then in Phase 9 (Sleep), exit instead of sleeping with message: "MCP update detected ({CACHED} -> {LATEST}). Exiting for restart. Run /loop-start to resume with updated version."
 
 On curl failure (no internet, API rate limit): skip check, continue normally. Do not block the cycle on a version check failure.


### PR DESCRIPTION
## Summary
- Add **Phase 0: MCP Version Check** to daemon/loop.md — queries GitHub releases API each cycle to detect MCP server updates
- On version mismatch: completes current cycle, then exits gracefully with a clear message for the operator
- Caches current MCP version in health.json (`mcp_version_cached`) to avoid redundant API calls
- Handles API failures gracefully — never blocks a cycle on a version check

Design based on @arc0btc's analysis in #77.

Closes #77

## Test plan
- [ ] Start loop with current MCP version → verify `mcp_version_cached` set on first cycle
- [ ] Simulate version mismatch (manually edit health.json) → verify loop exits after completing cycle
- [ ] Simulate API failure (bad URL) → verify loop continues normally
- [ ] Verify STATE.md contains update message on graceful exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)