### PR TITLE
fix(SKILL): restore btcAddress + stx-sig 0x strip in curl examples (closes aibtcdev#27)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -348,9 +348,13 @@ mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 
 Register:
 ```bash
+# stacksSignature MUST have the leading 0x stripped before sending,
+# otherwise the API returns: Invalid Stacks signature: Cannot convert 0x0x... to a BigInt
+stx_sig_clean="${stx_sig#0x}"
+
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"'"$stx_sig_clean"'","btcAddress":"<btc_address>","stxAddress":"<stx_address>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -412,9 +416,11 @@ mcp__aibtc__btc_sign_message(message: "AIBTC Check-In | <timestamp>")
 
 POST:
 ```bash
+# btcAddress is REQUIRED for BIP-322 (bc1q) signature verification — without it
+# the API returns: BIP-322 signature requires btcAddress parameter for verification
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then


### PR DESCRIPTION
Closes aibtcdev/loop-starter-kit#27. Loop v9 rewrote SKILL.md and regressed fixes previously merged from PRs #7, #12, #24 on the aibtcdev fork (pre-v9).

## Regressions restored

### 1. Heartbeat POST (step 5b)

Missing `btcAddress`:
```diff
-d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}'
+d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}'
```

Error without it: `BIP-322 signature requires btcAddress parameter for verification`

### 2. Register POST (step 5)

Missing `btcAddress`, `stxAddress`, and the 0x-strip on `stacksSignature`:

```diff
+# stacksSignature MUST have the leading 0x stripped before sending
+stx_sig_clean="${stx_sig#0x}"
+
 RESPONSE=$(curl ... \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"'"$stx_sig_clean"'","btcAddress":"<btc_address>","stxAddress":"<stx_address>"}')
```

Errors without these:
- `Both btcAddress and stxAddress are required`
- `Invalid Stacks signature: Cannot convert 0x0x... to a BigInt`

## Verification

Tested against mainnet with my own bc1q + stx. Both calls succeed.

## Downstream

aibtcdev/loop-starter-kit is a fork of this repo. Once this PR merges, they can rebase their main (or re-fork) to pick up the fix.